### PR TITLE
Comply with datetime library fromisoformat method

### DIFF
--- a/lecroyparser/__init__.py
+++ b/lecroyparser/__init__.py
@@ -193,7 +193,7 @@ class ScopeData(object):
         month = self.parseByte(pos + 11)
         year = self.parseWord(pos + 12)
 
-        secondFormat = "{:." + str(secondDigits) + "f}"
+        secondFormat = "{:0" + str(secondDigits + 3) + "." + str(secondDigits) + "f}"
         fullFormat = "{}-{:02d}-{:02d} {:02d}:{:02d}:" + secondFormat
 
         return fullFormat.format(year, month, day, hour, minute, second)


### PR DESCRIPTION
Datetime is a standard python library, which provisions the classes date and datetime, with the method fromisoformat. Left-padding with 0s for single digit seconds not including the decimal part is required for this method to comprehend the resulting string from parseTimeStamp method.